### PR TITLE
Constructor implementation

### DIFF
--- a/features/constructor.feature
+++ b/features/constructor.feature
@@ -1,0 +1,41 @@
+Feature: select values using query syntax
+  As a developer working with JSON-LD
+  I want to be able to use familiar syntax to query a JSON-LD document
+  So that I don't need to manually parse the expanded JSON tree
+
+  Background: Load sample data
+    Given the sample data containing a solitary field is loaded
+
+    Scenario: Construction using data and context
+      When I construct an ldQuery object using the loaded data and <context>
+        | context                             |
+        | { "ex": "http://www.example.org#" } |
+      Then I should obtain a QueryNode object
+
+    Scenario: Construction using data and context, then perform a selection test
+      When I construct an ldQuery object using the loaded data and <context>
+        | context                             |
+        | { "ex": "http://www.example.org#" } |
+       And I query for "ex:field @value"
+      Then the result should be "All by myself"
+
+    Scenario: Construction using context only
+      When I construct an ldQuery object using <context> only
+        | context                             |
+        | { "ex": "http://www.example.org#" } |
+      Then I should get a query factory object
+
+    Scenario: Construction using context only, then data
+      When I construct an ldQuery object using <context> only
+        | context                             |
+        | { "ex": "http://www.example.org#" } |
+       And I pass the loaded data to the query factory
+      Then I should obtain a QueryNode object
+
+    Scenario: Construction using context only, then data, then perform a selection test
+      When I construct an ldQuery object using <context> only
+        | context                             |
+        | { "ex": "http://www.example.org#" } |
+       And I pass the loaded data to the query factory
+       And I query for "ex:field @value"
+      Then the result should be "All by myself"

--- a/features/data/solitary.json
+++ b/features/data/solitary.json
@@ -1,0 +1,14 @@
+{
+
+    "@type": [
+
+        "http://www.example.org#solitary"
+
+    ],
+    "http://www.example.org#field": [ {
+
+        "@value": "All by myself"
+
+    } ]
+
+}

--- a/features/nested-selections.feature
+++ b/features/nested-selections.feature
@@ -2,10 +2,10 @@ Feature: select values using query syntax against documents with recursive prope
   As a developer working with JSON-LD
   I want to be able to use familiar syntax to query a JSON-LD document
   So that I don't need to manually parse the expanded JSON tree
-  
+
   Background: Load sample data
     Given the sample data containing recursive constructs is loaded
-    And I construct an ldQuery object using <context>
+    And I construct an ldQuery object using the loaded data and <context>
         | context                                                                                               |
         | { "ex": "http://www.example.org#" } |
 

--- a/features/selection.feature
+++ b/features/selection.feature
@@ -2,46 +2,46 @@ Feature: select values using query syntax
   As a developer working with JSON-LD
   I want to be able to use familiar syntax to query a JSON-LD document
   So that I don't need to manually parse the expanded JSON tree
-  
+
   Background: Load sample data
     Given the sample data containing favourite reads is loaded
-    And I construct an ldQuery object using <context>
+    And I construct an ldQuery object using the loaded data and <context>
         | context                                                                                               |
         | { "so": "http://schema.org/", "foaf": "http://xmlns.com/foaf/0.1/", "ex": "http://www.example.org#" } |
-    
+
     Scenario: Query for the first name node
       When I query for "foaf:firstName"
       Then the result should be a QueryNode object
-      
+
     Scenario: Query for first name values
       When I query for "foaf:firstName @value"
       Then the result should be "Andrew"
-    
+
     Scenario: Query for description value
       When I query for "so:description @value"
       Then the result should be "Linked person"
-    
+
     Scenario: Query for the first value
       When I query for "@value"
       Then the result should be "goofballLogic"
-      
+
     Scenario: Query for a property which isn't present on every branch of the tree
       When I query for "ex:note-to-self @value"
       Then the result should be "Need to finish reading this"
-    
+
     Scenario: Query for item in collection
       When I query for "ex:favouriteReads so:author @value"
       Then the result should be "Iain M Banks"
-      
+
     Scenario: Query for an item in a collection using method chaining
       Given I query for "ex:favouriteReads"
       When I query the result for "so:author @value"
       Then the result should be "Iain M Banks"
-    
+
     Scenario: Query for the first item in a collection not at the top level
       When I query for "so:author @value"
       Then the result should be "Iain M Banks"
-    
+
     Scenario: Get the JSON for a selected item
       Given I query for "ex:favouriteReads"
       When I get the result's json
@@ -52,7 +52,7 @@ Feature: select values using query syntax
     Scenario: Query for the author nodes
         When I query for all "ex:favouriteReads so:author"
         Then the result should be an array of 2 QueryNodes
-      
+
     Scenario: Query for author nodes, then for names
         When I query for all "ex:favouriteReads so:author"
         And then I query the result for all "@value"

--- a/features/step_definitions/selection.js
+++ b/features/step_definitions/selection.js
@@ -1,109 +1,149 @@
 var favouriteReads = JSON.stringify( require( "../data/person-favourite-reads.json" ) );
 var dataWithNesting = JSON.stringify( require( "../data/data-with-nesting.json" ) );
+var solitaryField = JSON.stringify( require( "../data/solitary.json" ) );
 var ldQuery = require( "../../src/ld-query" );
 var should = require( "should" );
 
 module.exports = function() {
-    
+
      // a fallback for missing Array.isArray
     var isArray = Array.isArray || function( arg ) {
-        
+
         return Object.prototype.toString.call( arg ) === "[object Array]";
-    
+
     };
-    
+
     this.Given(/^the sample data containing favourite reads is loaded$/, function () {
-    
+
         this.data = JSON.parse( favouriteReads );
-        
+
     } );
-    
+
     this.Given(/^the sample data containing recursive constructs is loaded$/, function () {
-         
+
          this.data = JSON.parse( dataWithNesting );
-         
+
     } );
-       
-    this.Given(/^I construct an ldQuery object using <context>$/, function (table) {
-        
+
+    this.Given(/^the sample data containing a solitary field is loaded$/, function () {
+
+         this.data = JSON.parse( solitaryField );
+
+    } );
+
+    this.Given(/^I construct an ldQuery object using the loaded data and <context>$/, function (table) {
+
         this.context = JSON.parse( table.hashes()[ 0 ].context );
         this.query = ldQuery( this.data, this.context );
-         
+
     } );
-    
+
+    this.Given(/^I construct an ldQuery object using <context> only$/, function (table) {
+
+        this.context = JSON.parse( table.hashes()[ 0 ].context );
+        this.queryFactory = ldQuery( this.context );
+
+    } );
+
+    this.Then(/^I should get a query factory object$/, function () {
+
+        // can only estimate this - check it is a function and not a QueryNode
+        should.exist( this.queryFactory, "No query factory object found" );
+        var isFunction = typeof this.queryFactory === "function";
+        isFunction.should.be.true( "Query factory is not a function" );
+
+        should.not.exist( this.queryFactory.query, "Unexpected query method found" );
+        should.not.exist( this.queryFactory.queryAll, "Unexpected queryAll method found" );
+
+    } );
+
+    this.Given(/^I pass the loaded data to the query factory$/, function () {
+
+        this.query = this.queryFactory( this.data );
+
+    } );
+
     this.When(/^I query for( all)? "([^"]*)"$/, function ( isAll, selector ) {
 
         this.result = isAll ? this.query.queryAll( selector ) : this.query.query( selector );
-        
+
     } );
-    
-    
+
+
     this.When( /^then I query the result for( all)? "([^"]*)"$/, function (isAll, selector ) {
-      
+
         if ( this.result.isFinal )  {
-            
+
             throw new Error( "Result was final - can't query any further" );
-            
+
         }
-        const querySite = [].concat( this.result || [] )[ 0 ];
+        var querySite = [].concat( this.result || [] )[ 0 ];
         this.result = isAll ? querySite.queryAll( selector ) : querySite.query( selector );
-        
+
     } );
-       
+
+    this.Then(/^I should obtain a QueryNode object$/, function() {
+
+        should.exist( this.query, "No query object found" );
+        should.exist( this.query.query, "No query method found" );
+        should.exist( this.query.queryAll, "No queryAll method found" );
+
+    } );
+
     this.Then(/^the result should be a QueryNode object$/, function() {
-      
+
         should.exist( this.result, "No query object found" );
         should.exist( this.result.query, "No query method found" );
         should.exist( this.result.queryAll, "No queryAll method found" );
-        
+
     } );
-    
+
     this.Then(/^the result should be "([^"]*)"$/, function( expected ) {
-        
+
         this.result.should.eql( expected );
-        
+
     } );
-    
+
     this.When(/^I query the result for "([^"]*)"$/, function( selector ) {
-        
+
         this.result = this.result.query( selector );
-        
+
     } );
-    
+
     this.When(/^I get the result's json$/, function () {
-       
-       this.json = this.result.json();  
-       
+
+       this.json = this.result.json();
+
     } );
-    
+
     this.Then(/^the json should match$/, function (table) {
-        
+
         var actual = JSON.stringify( JSON.parse( table.hashes()[ 0 ].json ) );
         var expected = JSON.stringify( this.json );
         actual.should.match( expected );
-        
+
     } );
-    
+
     this.Then(/^the result should be an array of (\d+) QueryNodes$/, function ( nodeCount ) {
-    
+
         should.exist( this.result, "No query list object found" );
         this.result.length.should.eql( parseInt( nodeCount ) );
         if ( nodeCount > 0 ) {
-            
+
             var sample = this.result[ 0 ];
             should.exist( sample.query, "No query method found" );
             should.exist( sample.queryAll, "No queryAll method found" );
-            
+
         }
-        
+
     } );
-    
+
     this.Then(/^the result should be an array (\[ [^\]]* \])$/, function ( csv ) {
-        
+
         var expected = JSON.stringify( JSON.parse( csv ) );
         var actual = JSON.stringify( this.result );
         actual.should.eql( expected );
 
     } );
-    
+
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ld-query",
   "version": "0.0.1",
   "description": "A tiny library to query expanded JSON-LD documents",
-  "main": "dist/ld-query.js",
+  "main": "src/ld-query.js",
   "scripts": {
     "test": "./node_modules/.bin/cucumberjs"
   },

--- a/src/ld-query.js
+++ b/src/ld-query.js
@@ -1,47 +1,53 @@
 ( function( x ) {
- 
+
     if( typeof module === "object" && module.exports ) {
-        
+
         module.exports = x;
-        
+
     } else {
 
-        window.LD = x; 
-        
+        window.LD = x;
+
     }
 
-}( function( dataContext, context ) {
+}( function( contextOrData, context ) {
+
+    // if only the first parameter is supplied, then use it as the context and return a factory function
+    // to create documents
+    var asFactory = !context;
+    context = context || contextOrData;
 
     // a fallback for missing Array.isArray
     var isArray = Array.isArray || function( arg ) {
-        
+
         return Object.prototype.toString.call( arg ) === "[object Array]";
-    
+
     };
-    
+
     // this builds a set of nested functions which are capable of expanding namespace alises to full prefixes
+    // if two parameters are provided then use the second parameter, otherwise use the first parameter.
     var expand = Object.keys( context )
 
         // for each alias (e.g. "so"), create a function to add to our chain
         .reduce( function( prior, alias ) {
-            
-            // create a regex for this alias    
+
+            // create a regex for this alias
             var expr = new RegExp( "^" + alias + ":", "g" );
-            
-            // return a new function to process the property name 
+
+            // return a new function to process the property name
             return function( propName ) {
-                
+
                 // if there are already functions in the chain, call them first
                 if ( prior ) { propName = prior( propName ); }
-                
+
                 // then return the result of de-aliasing this alias
                 return ( propName || "" ).replace( expr, context[ alias ] );
-                
+
             };
-        
+
         }, null );
 
-    
+
     function seek( json, assessPath, isSeekAll, path ) {
 
         var acc = isSeekAll ? [] : null;
@@ -51,12 +57,12 @@
 
             if ( !isSeekAll ) { return json; }
             acc.push( json );
-            
-            
+
+
         } else if ( isArray( json ) ) {
-            
+
             for( var i = 0; i < json.length; i++ ) {
-                
+
                 var found = seek( json[ i ], assessPath, isSeekAll, path )
                 if ( found ) {
 
@@ -64,29 +70,29 @@
                     acc = acc.concat( found );
 
                 }
-                
+
             }
-            
+
         } else if ( typeof json === "object" ) {
-            
+
             for( var prop in json ) {
-                
+
                 var propPath = path.concat( prop );
                 var found = seek( json[ prop ], assessPath, isSeekAll, propPath )
                 if ( found ) {
-                    
+
                     if( !isSeekAll ) { return found; }
                     acc = acc.concat( found );
-                    
+
                 }
-                
+
             }
-            
+
         }
         return acc;
 
     }
-    
+
     function assessPathForSteps( steps ) {
 
         return function assessPath( nodePath ) {
@@ -94,74 +100,88 @@
             var bookmark = 0;
             if ( !nodePath ) { return false; }
             return steps.every( function( step ) {
-                
+
                 // find the next step starting from the bookmarked offset
                 bookmark = nodePath.indexOf( step, bookmark );
                 // the test passes if the step was found
                 return ~bookmark;
-                
+
             } );
-            
+
         };
 
     }
-            
+
     // select json for this path
     function select( json, path ) {
-        
+
         var steps = path.split( " " ).map( expand );
         if ( !steps.length ) { return { json: null }; }
         var found = seek( json, assessPathForSteps( steps ) );
         var lastStep = steps[ steps.length - 1 ];
         return {
-            
+
             json: found,
             isFinal: ( found === null ) || lastStep === "@value"
-            
+
         };
 
     }
-    
+
     // select jsons for this path
     function selectAll( json, path ) {
-        
+
         var steps = path.split( " " ).map( expand );
         if ( !steps.length ) { return { json: [] }; }
         var found = seek( json, assessPathForSteps( steps ), true );
         var lastStep = steps[ steps.length - 1 ];
         return {
-            
+
             json: found,
             isFinal: ( found === [] ) || lastStep === "@value"
-            
+
         };
-        
+
     }
     function QueryNode( jsonData ) {
-    
+
         this.json = function() { return jsonData; };
 
     }
-    
+
     function buildQueryNode( jsonData ) { return new QueryNode( jsonData ); }
-    
+
     QueryNode.prototype.query = function( path ) {
 
-        // select the json targetted by this path    
+        // select the json targetted by this path
         var selection = select( this.json(), path );
         // if the result is "final" (e.g. @value), just return the json raw
         return selection.isFinal ? selection.json : new QueryNode( selection.json );
-        
+
     };
     QueryNode.prototype.queryAll = function( path ) {
-        
+
         // select the json targetted by this path
         var selections = selectAll( this.json(), path );
         // if the result is "final" (e.g. @value), return an array of the raw json
         return selections.isFinal ? selections.json : selections.json.map( buildQueryNode );
 
     };
-    return new QueryNode( dataContext );
+
+    if ( asFactory ) {
+
+        // if one parameter was supplied, return the factory function
+        return function( dataContext ) {
+
+            return new QueryNode( dataContext );
+
+        }
+
+    } else {
+
+        // if two parameters were supplied, return the QueryNode directly
+        return new QueryNode( contextOrData );
+
+    }
 
 } ) );
-    


### PR DESCRIPTION
The README.md mentions a constructor pattern

```
var context = LD( { ... etc. } );
var doc = context( data );
```

that is not actually implemented. This pull supplies the missing constructor pattern.
