### PR TITLE
Updated attribute matching to handle attribute arrays

### DIFF
--- a/features/data/operations.json
+++ b/features/data/operations.json
@@ -1,0 +1,40 @@
+{
+    "@type": [
+        "http://www.example.org#operationList"
+    ],
+    "http://www.w3.org/ns/hydra/core#operation": [
+        {
+            "@type": [
+                "http://www.example.org#deleteOperation",
+                "http://www.w3.org/ns/hydra/core#DeleteResourceOperation"
+            ],
+            "http://www.w3.org/ns/hydra/core#method": [
+                {
+                    "@value": "DELETE"
+                }
+            ],
+            "http://www.w3.org/ns/hydra/core#title": [
+                {
+                    "@value": "Delete the thing"
+                }
+            ]
+        },
+        {
+            "@type": [
+                "http://www.example.org#createOperation",
+                "http://www.w3.org/ns/hydra/core#CreateResourceOperation"
+            ],
+            "http://www.w3.org/ns/hydra/core#method": [
+                {
+                    "@value": "PUT"
+                }
+            ],
+            "http://www.w3.org/ns/hydra/core#title": [
+                {
+                    "@value": "Create the thing"
+                }
+            ]
+        }
+    ]
+
+}

--- a/features/selection-by-type.feature
+++ b/features/selection-by-type.feature
@@ -1,0 +1,18 @@
+Feature: select values by type using query syntax
+  As a developer working with JSON-LD
+  I want to be able to use familiar syntax to query a JSON-LD document
+  So that I don't need to manually parse the expanded JSON tree
+
+  Background: Load sample data
+    Given the sample data containing operations is loaded
+    And I construct an ldQuery object using the loaded data and <context>
+        | context                                                                          |
+        | { "ex": "http://www.example.org#", "hydra": "http://www.w3.org/ns/hydra/core#" } |
+
+    Scenario: Query for operation by first type
+        When I query for "hydra:operation[@type=ex:deleteOperation] hydra:title @value"
+        Then the result should be "Delete the thing"
+
+    Scenario: Query for operation by second type
+        When I query for "hydra:operation[@type=hydra:CreateResourceOperation] hydra:title @value"
+        Then the result should be "Create the thing"

--- a/features/step_definitions/selection.js
+++ b/features/step_definitions/selection.js
@@ -1,6 +1,7 @@
 var favouriteReads = JSON.stringify( require( "../data/person-favourite-reads.json" ) );
 var dataWithNesting = JSON.stringify( require( "../data/data-with-nesting.json" ) );
 var solitaryField = JSON.stringify( require( "../data/solitary.json" ) );
+var operations = JSON.stringify( require( "../data/operations.json" ) );
 var ldQuery = require( "../../src/ld-query" );
 var should = require( "should" );
 
@@ -28,6 +29,12 @@ module.exports = function() {
     this.Given(/^the sample data containing a solitary field is loaded$/, function () {
 
          this.data = JSON.parse( solitaryField );
+
+    } );
+
+    this.Given(/^the sample data containing operations is loaded$/, function () {
+
+         this.data = JSON.parse( operations );
 
     } );
 

--- a/src/ld-query.js
+++ b/src/ld-query.js
@@ -47,13 +47,27 @@
 
         }, null );
 
+    function testObjectMatches( json, clause ) {
+
+        var val = json[ clause.where ];
+        if ( !val ) { return false; }
+        if ( isArray( val ) ) {
+
+            return !!~val.indexOf( clause.value );
+
+        }
+
+        return val === clause.value;
+
+    }
+
     function seekInObject( json, remainingMatchers, isSeekAll, found ) {
 
         var currentMatcher = remainingMatchers[ 0 ];
         if ( currentMatcher.where ) {
 
             // if the current matcher is a 'where' evaluate against the json itself
-            if ( json[ currentMatcher.where ] === currentMatcher.value ) {
+            if ( testObjectMatches( json, currentMatcher ) ) {
 
                 if ( remainingMatchers.length === 1 ) { found.push( json ); }
                 else { seek( json, remainingMatchers.slice( 1 ), isSeekAll, found ); }
@@ -113,7 +127,7 @@
             var where = /^\[(.+?)=(.+?)\](.*)/.exec( remainder );
             if ( where ) {
 
-                matchers.push( { where : where[ 1 ].trim(), value: where[ 2 ].trim() } );
+                matchers.push( { where : where[ 1 ].trim(), value: expand( where[ 2 ].trim() ) } );
                 remainder = ( where[ 3 ] || "" ).trim();
 
             } else {


### PR DESCRIPTION
I realised the attribute matching code couldn't handle attributes that were arrays e.g.

```
            "@type": [
                "http://www.example.org#deleteOperation",
                "http://www.w3.org/ns/hydra/core#DeleteResourceOperation"
            ],
```

I've updated and added additional scenarios
