### PR TITLE
Change how the selection path is built

### DIFF
--- a/features/data/selection-tests.json
+++ b/features/data/selection-tests.json
@@ -55,7 +55,6 @@
             "@value": "Three"
         }]
     }, {
-        
         "http://www.example.org#parent": [{
             "@index": "index2",
             "@value": "I am parent",


### PR DESCRIPTION
I've adjusted the regexes in the extractStep function, so it will now spot a space in front of a [attr=value] block and handle that as a separate step, rather than joining it to the previous.

I also noticed that when walking through the steps, the assessPath method was starting a test on the current node, not on the nodes beneath.

This is a fix for issue https://github.com/goofballLogic/ld-query/issues/17
