### PR TITLE
Reimplementation of graph walk to optimize performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,30 @@ doc.queryAll("@type")                                            // [ [ "http://
 
 ```
 
+## Benchmarking
+
+Note: The benchmarking tools require that you have `git` available on the path.
+
+To benchmark the current version of the library against the latest commit to
+the `master` branch, run:
+
+```
+npm run benchmark
+```
+
+To benchmark the current version of the library against a particular commit,
+branch or tag, run:
+
+```
+npm run benchmark -- --compare-to <commit|branch|tag>
+```
+
+To run only a subset of benchmarks, run:
+
+```
+npm run benchmark -- --benchmark "<regexp matching benchmark names>"
+```
+
 [W3C JSON-LD recommendation]: https://www.w3.org/TR/json-ld/
 [JSON-LD Processing Algorithms and API recommendation]: https://www.w3.org/TR/json-ld-api/#expansion
 [jsonld.js]: https://github.com/digitalbazaar/jsonld.js

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,0 +1,180 @@
+var Benchmark = require("benchmark");
+var spawn = require("child_process").spawnSync;
+var fs = require("fs");
+var Table = require("easy-table");
+var tmp = require("tmp");
+var selectionSuite = require("./selection.js");
+tmp.setGracefulCleanup();
+
+var OPTS = ( function(args) {
+    var ret = {
+
+        benchmark: /.*/,
+        compareTo: "master",
+        precision: 6
+        
+    };
+    
+    for ( var ii = 0; ii < args.length; ii++ ) {
+
+        var arg = args[ ii ];
+
+        switch( arg ) {
+
+        case "--compare-to":
+            ret.compareTo = args[ ++ii ]
+            break;
+
+        case "--benchmark":
+            ret.benchmark = new RegExp(args[ ++ii ]);
+            break;
+
+        case "--precision":
+            ret.precision = args[ ++ii ];
+            break;
+
+        default:
+            console.log( "Unknown argument: " + arg );
+
+        }
+
+    }
+    
+    return ret;
+    
+}( process.argv.slice( 2 ) ) );
+
+function createSuite( name, LD ) {
+    var suite = new Benchmark.Suite( name );
+
+    var benchmarks = selectionSuite( LD );
+    
+    var bmFilter = OPTS.benchmark;
+    return benchmarks
+        .filter( function( bm ) { return bmFilter.test( bm.name ); } )
+        .reduce( function( s, bm ) { return s.add( bm.name, bm.fn ); },
+                 suite );
+
+}
+
+function checkoutModuleAtPath(path) {
+
+    var file = tmp.fileSync();
+
+    var source = spawn( 'git', [
+        "show",
+        path + ":src/ld-query.js",
+    ] ).stdout;
+
+    fs.writeFileSync( file.fd, source );
+        
+    return file.name;
+
+}
+
+var compareToPath = OPTS.compareTo;
+
+var modules = [ [ "Working Copy", "../src/ld-query.js" ],
+                [ compareToPath, checkoutModuleAtPath( compareToPath ) ] ];
+var suites = [];
+var results = [];
+
+modules
+    .map( function( m ) { return createSuite( m[0], require( m[1] ) ); } )
+    .forEach(function( m ) { suites.push( m ); } );
+
+function indexBenchmarksByName(result, bm) {
+
+    result[ bm.name ] = { mean: bm.stats.mean };
+    return result;
+
+}
+
+function checkSuitesForErrors(suites) {
+
+    var errors = suites
+        .map(function(suite) {
+            return suite
+                .filter(function(bm) { return !!bm.error; })
+                .map(function(bm) { return [suite.name, bm.name, bm.error]; });
+        })
+        .reduce(function(results, suiteResults) {
+            return results.concat(suiteResults);
+        }, []);
+
+    if (0 !== errors.length) {
+
+        errors.forEach(function(r) {
+            var suite     = r[0];
+            var benchmark = r[1];
+            var error     = r[2];
+            console.log("Suite: " + suite +
+                        ", Benchmark: " + benchmark +
+                        " failed with error:\n", error);
+        });
+
+        throw new Error("Benchmarks failed");
+    }
+    
+}
+
+function processResults() {
+    checkSuitesForErrors(results);
+    
+    var current = results[ 0 ];
+    var currentByName = current.reduce( indexBenchmarksByName, {} );
+
+    var other = results[ 1 ];
+    var otherByName = other.reduce( indexBenchmarksByName, {} );
+
+    var resultTable = new Table;
+    var numberFormat = Table.number( OPTS.precision );
+
+    Object.keys(currentByName).forEach( function( bmName ) {
+
+        resultTable.cell( "Benchmark", bmName );
+        var currBM = currentByName[ bmName ];
+        var otherBM = otherByName[ bmName ];
+        
+        resultTable.cell( current.name, currBM.mean * 1000, numberFormat );
+        resultTable.cell( other.name, otherBM.mean * 1000, numberFormat );
+
+        var diffPercentage =
+            ( ( currBM.mean - otherBM.mean ) / otherBM.mean ) * 100;
+        resultTable.cell( "% Difference", diffPercentage, numberFormat );
+
+        resultTable.newRow();
+
+    } );
+    
+    console.log( "\nResults:\n" );
+    console.log( "Mean Execution Time (milliseconds):\n" );
+    console.log( resultTable.toString() );
+
+}
+
+function executeSuites() {
+
+    if ( 0 === suites.length ) {
+
+        processResults();
+
+    } else {
+
+        var suite = suites.shift()
+
+        console.log("Benchmarking:", suite.name);
+
+        suite
+            .on("complete", function() {
+
+                results.push( this );
+                executeSuites();
+                
+            })
+            .run();
+    }
+    
+}
+
+executeSuites();

--- a/benchmark/data/selection-tests.json
+++ b/benchmark/data/selection-tests.json
@@ -1,0 +1,382 @@
+{
+    "@type": [
+        "http://www.example.org#unrealistic-data-with-no-decent-analogy"
+    ],
+    "http://www.example.org#type": [{
+        "@id": "http://www.example.org#type1",
+        "@index": "index1",
+        "@type": [
+            "http://www.example.org#type-child",
+            "one"
+        ],
+        "http://www.example.org#type": [{
+            "@id": "http://www.example.org#type2",
+            "@index": "index2",
+            "@type": [
+                "http://www.example.org#type-child",
+                "two"
+            ],
+            "http://www.example.org#grabThis": [{
+                "@value": "One-Two"
+            }]
+        }],
+        "http://www.example.org#grabThis": [{
+            "@value": "One"
+        }]
+    }, {
+        "@id": "http://www.example.org#type3",
+        "@index": "index3",
+        "@type": [
+            "http://www.example.org#type-child",
+            "three"
+        ],
+        "http://www.example.org#type": [{
+            "@id": "http://www.example.org#type4",
+            "@type": [
+                "http://www.example.org#type-child",
+                "four-noindex"
+            ],
+            "http://www.example.org#type": [{
+                "@id": "http://www.example.org#type5",
+                "@index": "index4",
+                "@type": [
+                    "http://www.example.org#type-child",
+                    "four"
+                ],
+                "http://www.example.org#grabThis": [{
+                    "@value": "Three-Four"
+                }]
+            }],
+            "http://www.example.org#grabThis": [{
+                "@value": "Three-NoIndex"
+            }]
+        }],
+        "http://www.example.org#grabThis": [{
+            "@value": "Three"
+        }]
+    }, {
+        "http://www.example.org#parent": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }, {
+        "http://www.example.org#parent2": [{
+            "@index": "index2",
+            "@value": "I am parent",
+            "http://www.example.org#child": [{
+                "@index": "index1",
+                "@value": "I am child 1"
+            }, {
+                "@index": "index2",
+                "@value": "I am child 2"
+            }]
+        }]
+    }]
+}

--- a/benchmark/selection.js
+++ b/benchmark/selection.js
@@ -1,0 +1,128 @@
+var DATA = require( "./data/selection-tests.json" )
+var CONTEXT = {
+    "ex": "http://www.example.org#"
+}
+
+/*
+ * We don't use `should` here since the overhead is actually significant
+ * for some of the benchmarks, and the assertions are really just a sanity
+ * check, rather than being the purpose of the tests that run them, so we
+ * only have a few assertion types.
+ */
+
+function assertEquals( actual, expected, msg ) {
+
+    if ( actual !== expected )
+        throw new Error( "Expected: '" + expected
+                         + "', found: '" + actual + "'");
+
+}
+
+function assertLength( obj, expected ) {
+
+    if ( obj.length !== expected )
+        throw new Error( "Expected obj: " + obj
+                        + " to have length: " + expected
+                        + ", actual length: " + obj.length);
+    
+}
+
+module.exports = function ( LD ) {
+
+    var selectionDoc = LD( DATA, CONTEXT );
+
+    return [
+        {
+            name: "Query single value (reuse doc)",
+            fn: function() {
+                
+                var actual = selectionDoc
+                    .query( "ex:grabThis @value" );
+                assertEquals(actual, "One-Two");
+                
+            }
+        },
+        {
+            name: "Query all values (reuse doc)",
+            fn: function() {
+                
+                var actual = selectionDoc
+                    .queryAll( "ex:grabThis @value" );
+                assertLength( actual, 5 );
+                
+            }
+        },
+        {
+            name: "Query single value (fresh doc)",
+            fn: function() {
+                
+                var doc = LD( DATA, CONTEXT );
+                var actual = doc.query( "ex:grabThis @value" );
+                assertEquals(actual, "One-Two");
+                
+            }
+        },
+        {
+            name: "Query single value (fresh doc, no pathcache)",
+            fn: function() {
+                
+                var doc = LD( DATA, CONTEXT );
+                if (doc.withPathCaching)
+                    doc.withPathCaching(false);
+
+                var actual = doc.query( "ex:grabThis @value" );
+                assertEquals(actual, "One-Two");
+                
+            }
+        },
+        {
+            name: "Query all values (fresh doc)",
+            fn: function() {
+                
+                var actual = LD( DATA, CONTEXT )
+                    .queryAll( "ex:grabThis @value" );
+                assertLength( actual, 5 );
+                
+            }
+        },
+        {
+            name: "Select all by predicate",
+            fn: function() {
+                
+                var actual = selectionDoc
+                    .queryAll( "*[@type=four-noindex]" );
+                assertLength( actual, 1 );
+                
+            }
+        },
+        {
+            name: "Select direct child",
+            fn: function() {
+                
+                var actual = selectionDoc
+                    .queryAll( "ex:type > ex:type" );
+                /*
+                 * This test returns different results from versions before
+                 * the `faster` branch, so we have to comment out the assert
+                 * for now
+                 */
+                // assertLength( actual, 2 );
+                
+            }
+        },
+        {
+            name: "Select nested",
+            fn: function() {
+                
+                var actual = selectionDoc
+                    .query( "ex:type > ex:type[@type=four-noindex]" )
+                    .queryAll( "ex:grabThis @value" );
+                assertLength( actual, 2 );
+                
+            }
+        }
+
+    ];
+    
+}
+

--- a/features/selection.feature
+++ b/features/selection.feature
@@ -47,7 +47,7 @@ Feature: select values using query syntax
       When I get the result's json
       Then the json should match
         | json                                                                                                                                             |
-        | [{"@id":"http://www.isbnsearch.org/isbn/9780553575378","@index":"banks-exc","@type":["http://schema.org/Book"],"http://schema.org/author":[{"@value":"Iain M Banks"}],"http://schema.org/name":[{"@value":"Excession"}]},{"@id":"http://www.isbnsearch.org/isbn/9780143039945","@index":"pynchon-gr","@type":["http://schema.org/Book","http://schema.org/Movie"],"http://schema.org/author":[{"@value":"Thomas Pynchon"}],"http://schema.org/name":[{"@value":"Gravity's Rainbow"}],"http://www.example.org#note-to-self":[{"@value":"Need to finish reading this"}]}] |
+        | {"@id":"http://www.isbnsearch.org/isbn/9780553575378","@index":"banks-exc","@type":["http://schema.org/Book"],"http://schema.org/author":[{"@value":"Iain M Banks"}],"http://schema.org/name":[{"@value":"Excession"}]} |
 
     Scenario: Query for the author nodes
         When I query for all "ex:favouriteReads author"

--- a/features/step_definitions/selection.js
+++ b/features/step_definitions/selection.js
@@ -132,8 +132,8 @@ module.exports = function() {
 
     this.Then(/^the json should match$/, function (table) {
 
-        var actual = JSON.stringify( JSON.parse( table.hashes()[ 0 ].json ) );
-        var expected = JSON.stringify( this.json );
+        var expected = JSON.stringify( JSON.parse( table.hashes()[ 0 ].json ) );
+        var actual = JSON.stringify( this.json );
         actual.should.match( expected );
 
     } );

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A tiny library to query expanded JSON-LD documents",
   "main": "src/ld-query.js",
   "scripts": {
-    "test": "./node_modules/.bin/cucumberjs"
+    "test": "./node_modules/.bin/cucumberjs",
+    "benchmark" : "node ./benchmark/benchmark.js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,11 @@
   },
   "homepage": "https://github.com/goofballLogic/ld-query#readme",
   "devDependencies": {
+    "benchmark" : "^2.1.4",
     "cucumber": "^1.2.0",
-    "should": "^9.0.2"
+    "easy-table" : "^1.1.0",
+    "microtime" : "^2.1.5",
+    "should": "^9.0.2",
+    "tmp" : "^0.0.31"
   }
 }


### PR DESCRIPTION
PnS testing of one of our apps which makes extensive use of ld-query indicated some room for improvement to substantially improve performance and reduce CPU usage on our node servers; this version caches both parsed steps and paths per document, as well as making better use of arrays in the inner loops (`push` vs `unshift` / `[].concat(old)`).

We've tried running with this patch on our in house environment, and are seeing roughly a 50% reduction in CPU consumption overall.

You can test the results locally by checking out this branch and running:

```
npm run benchmark
```

which will compare this branch to `master`

During the implementation of this, I noticed that some of the handling around array valued nodes seemed incorrect; the current master branch will return an array as the result of `query` if the path traversal ends at a property whose value is an array, but this seems inconsistent with the expected handling of arrays; that each item in the array is one particular solution to the query. I would expect query to always return the first item of such an array (with the exception of `@type`, which is always known to be an array of strings, never an array of entities).